### PR TITLE
removed noreturn attributes

### DIFF
--- a/components/esp_common/include/esp_err.h
+++ b/components/esp_common/include/esp_err.h
@@ -78,7 +78,7 @@ const char *esp_err_to_name(esp_err_t code);
 const char *esp_err_to_name_r(esp_err_t code, char *buf, size_t buflen);
 
 /** @cond */
-void _esp_error_check_failed(esp_err_t rc, const char *file, int line, const char *function, const char *expression) __attribute__((noreturn));
+void _esp_error_check_failed(esp_err_t rc, const char *file, int line, const char *function, const char *expression);
 
 /** @cond */
 void _esp_error_check_failed_without_abort(esp_err_t rc, const char *file, int line, const char *function, const char *expression);

--- a/components/esp_rom/include/esp32c3/rom/libc_stubs.h
+++ b/components/esp_rom/include/esp32c3/rom/libc_stubs.h
@@ -77,7 +77,7 @@ struct syscall_stub_table
     void (*_retarget_lock_release_recursive)(_LOCK_T lock);
     int (*_printf_float)(struct _reent *data, void *pdata, FILE * fp, int (*pfunc) (struct _reent *, FILE *, const char *, size_t len), va_list * ap);
     int (*_scanf_float) (struct _reent *rptr, void *pdata, FILE *fp, va_list *ap);
-    void (*__assert_func) (const char *file, int line, const char * func, const char *failedexpr) __attribute__((noreturn));
+    void (*__assert_func) (const char *file, int line, const char * func, const char *failedexpr);
     void (*__sinit) (struct _reent *r);
     void (*_cleanup_r) (struct _reent* r);
 };

--- a/components/esp_rom/include/esp32s3/rom/libc_stubs.h
+++ b/components/esp_rom/include/esp32s3/rom/libc_stubs.h
@@ -78,7 +78,7 @@ struct syscall_stub_table
     void (*_retarget_lock_release_recursive)(_LOCK_T lock);
     int (*_printf_float)(struct _reent *data, void *pdata, FILE * fp, int (*pfunc) (struct _reent *, FILE *, const char *, size_t len), va_list * ap);
     int (*_scanf_float) (struct _reent *rptr, void *pdata, FILE *fp, va_list *ap);
-    void (*__assert_func) (const char *file, int line, const char * func, const char *failedexpr) __attribute__((noreturn));
+    void (*__assert_func) (const char *file, int line, const char * func, const char *failedexpr);
     void (*__sinit) (struct _reent *r);
     void (*_cleanup_r) (struct _reent* r);
 };

--- a/components/esp_system/include/esp_private/panic_internal.h
+++ b/components/esp_system/include/esp_private/panic_internal.h
@@ -76,7 +76,7 @@ void panic_print_hex(int h);
 #define panic_print_hex(h)
 #endif
 
-void __attribute__((noreturn)) panic_abort(const char *details);
+void panic_abort(const char *details);
 
 void panic_arch_fill_info(void *frame, panic_info_t *info);
 

--- a/components/esp_system/include/esp_system.h
+++ b/components/esp_system/include/esp_system.h
@@ -257,7 +257,7 @@ esp_err_t esp_derive_local_mac(uint8_t* local_mac, const uint8_t* universal_mac)
  *
  * @param details Details that will be displayed during panic handling.
  */
-void  __attribute__((noreturn)) esp_system_abort(const char* details);
+void esp_system_abort(const char* details);
 
 /**
  * @brief Chip models

--- a/components/esp_system/panic.c
+++ b/components/esp_system/panic.c
@@ -387,7 +387,7 @@ void esp_panic_handler(panic_info_t *info)
 }
 
 
-void IRAM_ATTR __attribute__((noreturn)) panic_abort(const char *details)
+void IRAM_ATTR panic_abort(const char *details)
 {
     g_panic_abort = true;
     s_panic_abort_details = (char *) details;

--- a/components/esp_system/system_api.c
+++ b/components/esp_system/system_api.c
@@ -107,7 +107,7 @@ const char *esp_get_idf_version(void)
     return IDF_VER;
 }
 
-void __attribute__((noreturn)) esp_system_abort(const char *details)
+void esp_system_abort(const char *details)
 {
     panic_abort(details);
 }

--- a/components/newlib/abort.c
+++ b/components/newlib/abort.c
@@ -19,7 +19,7 @@
 #include "soc/soc_caps.h"
 #include "hal/cpu_hal.h"
 
-void __attribute__((noreturn)) abort(void)
+void abort(void)
 {
     #define ERR_STR1  "abort() was called at PC 0x"
     #define ERR_STR2  " on core "

--- a/components/newlib/assert.c
+++ b/components/newlib/assert.c
@@ -37,7 +37,7 @@ static inline void ra_to_str(char *addr)
 /* Overriding assert function so that whenever assert is called from critical section,
  * it does not lead to a crash of its own.
  */
-void __attribute__((noreturn)) __assert_func(const char *file, int line, const char *func, const char *expr)
+void __assert_func(const char *file, int line, const char *func, const char *expr)
 {
 #if CONFIG_COMPILER_OPTIMIZATION_ASSERTIONS_SILENT
     char buff[sizeof(ASSERT_STR) + 11 + 1] = ASSERT_STR;
@@ -86,7 +86,7 @@ void __attribute__((noreturn)) __assert_func(const char *file, int line, const c
 #endif  /* CONFIG_COMPILER_OPTIMIZATION_ASSERTIONS_SILENT */
 }
 
-void __attribute__((noreturn)) __assert(const char *file, int line, const char *failedexpr)
+void __assert(const char *file, int line, const char *failedexpr)
 {
     __assert_func(file, line, NULL, failedexpr);
 }


### PR DESCRIPTION
Removed `noreturn` attribute to enable backtrace on task watchdog timeouts