### PR TITLE
esp_execute_shared_stack_function always restored the stack watchpoint

### DIFF
--- a/components/riscv/expression_with_stack_riscv.c
+++ b/components/riscv/expression_with_stack_riscv.c
@@ -66,7 +66,10 @@ void esp_execute_shared_stack_function(SemaphoreHandle_t lock, void *stack, size
 
     //Restore current task stack:
     current->pxDummy6 = (StackType_t *)current_task_stack;
+
+#if CONFIG_FREERTOS_WATCHPOINT_END_OF_STACK
     vPortSetStackWatchpoint(current->pxDummy6);
+#endif /* CONFIG_FREERTOS_WATCHPOINT_END_OF_STACK*/
     portEXIT_CRITICAL(&shared_stack_spinlock);
 
     xSemaphoreGive(lock);

--- a/components/xtensa/expression_with_stack_xtensa.c
+++ b/components/xtensa/expression_with_stack_xtensa.c
@@ -77,7 +77,9 @@ void esp_execute_shared_stack_function(SemaphoreHandle_t lock, void *stack, size
 
     //Restore current task stack:
     current->pxDummy6 = (StackType_t *)current_task_stack;
+#if CONFIG_FREERTOS_WATCHPOINT_END_OF_STACK
     vPortSetStackWatchpoint(current->pxDummy6);
+#endif /* CONFIG_FREERTOS_WATCHPOINT_END_OF_STACK*/
     portEXIT_CRITICAL(&xtensa_shared_stack_spinlock);
 
     xSemaphoreGive(lock);


### PR DESCRIPTION
regardless of CONFIG_FREERTOS_WATCHPOINT_END_OF_STACK. This would lead to an abondoned but active watchpoint on a former stack once the task calling esp_execute_shared_stack_function is deleted, if CONFIG_FREERTOS_WATCHPOINT_END_OF_STACK is inactive.